### PR TITLE
feat: implement TSV-to-JSON pre-processor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+
+# Don't track the test data files
+/test_data/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[codz]

--- a/src/prochariot/__init__.py
+++ b/src/prochariot/__init__.py
@@ -5,8 +5,8 @@ This package can be run in the command line using the `prochariot` command
 or imported as a module to run its functions in Python scripts.
 """
 
-# Import the main function from the core module
-from .core import analyze
+# Import functions from the core module
+from .core import analyze, parse_bakta_tsv
 
 # This tells Python what to export when a user does 'from prochariot import *'
-__all__ = ['analyze']
+__all__ = ['analyze', 'parse_bakta_tsv']

--- a/src/prochariot/core.py
+++ b/src/prochariot/core.py
@@ -10,6 +10,7 @@ Functions included:
 from pathlib import Path
 import pandas as pd
 import groq
+import json
 
 # -------------[ HELPERS ]-------------
 def _dbxrefs_to_dict(dbxrefs: str) -> dict:
@@ -70,7 +71,27 @@ def parse_bakta_tsv(tsv_file: Path) -> pd.DataFrame:
 
     return df
 
-# -------------[ CORE FUNCTION ]-------------
+def df_to_json(df: pd.DataFrame) -> str:
+    """
+    Converts a Pandas DataFrame to a JSON-formatted string, handling NaN values.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        The DataFrame to convert.
+
+    Returns
+    -------
+    str
+        The JSON-formatted string representation of the DataFrame.
+    """
+    # Replace all pandas 'NaN' with Python's 'None'
+    df = df.replace({pd.NA: None})
+    
+    # Convert the DataFrame to a JSON string
+    return df.to_json(orient="records")
+
+# -------------[ CORE ANALYZE FUNCTION ]-------------
 def analyze(input_directory: str, output_directory: str | None = ".", species: str | None = None, note: str | None = None) -> str:
     """
     Performs an LLM-guided analysis of a Bakta output directory.
@@ -109,6 +130,11 @@ if __name__ == "__main__":
     # Testing constants
     TSV_PATH = Path("../../test_data/st177_vre_bakta/assembly.tsv")
 
-    # Test the parse_bakta_tsv function
+    # Test pipeline
     df = parse_bakta_tsv(TSV_PATH)
-    print(df.head())
+    json_output = df_to_json(df)
+    
+    # Print the first couple of rows of JSON output nicely formatted
+    parsed_json = json.loads(json_output)
+    print(json.dumps(parsed_json[:4], indent=4))
+    

--- a/src/prochariot/core.py
+++ b/src/prochariot/core.py
@@ -8,6 +8,7 @@ Functions included:
 """
 # -------------[ LIBRARIES ]-------------
 from pathlib import Path
+import pandas as pd
 import groq
 
 # -------------[ HELPERS ]-------------
@@ -15,9 +16,9 @@ import groq
 # Section for future _helper() functions
 
 # -------------[ CORE COMPONENTS ]-------------
-def parse_bakta_tsv(tsv_file: Path) -> list[dict]
+def parse_bakta_tsv(tsv_file: Path) -> pd.DataFrame:
     """
-    Parses a Bakta .tsv file into a clean list of dictionaries.
+    Parses a Bakta .tsv file into a clean Pandas DataFrame.
 
     This function is publicly available. It parses the main columns
     and unnests the 'DbXrefs' column into a nested dictionary.
@@ -29,10 +30,15 @@ def parse_bakta_tsv(tsv_file: Path) -> list[dict]
 
     Returns
     -------
-    list[dict]
-        A list of dictionaries, where each dict is a processed feature.
+    pd.DataFrame
+        A Pandas DataFrame containing the parsed data.
     """
-    pass
+   
+    # Read the TSV file into a DataFrame
+    # Skipping the first 5 metadata rows
+    df = pd.read_csv(tsv_file, sep="\t", header=5) 
+
+    return df
 
 # -------------[ CORE FUNCTION ]-------------
 def analyze(input_directory: str, output_directory: str | None = ".", species: str | None = None, note: str | None = None) -> str:
@@ -66,3 +72,13 @@ def analyze(input_directory: str, output_directory: str | None = ".", species: s
     #TODO: Implement function logic
     pass
 
+
+# -------------[ TESTING HARNESS ]-------------
+if __name__ == "__main__":
+
+    # Testing constants
+    TSV_PATH = Path("../../test_data/st177_vre_bakta/assembly.tsv")
+
+    # Test the parse_bakta_tsv function
+    df = parse_bakta_tsv(TSV_PATH)
+    print(df.head())

--- a/src/prochariot/core.py
+++ b/src/prochariot/core.py
@@ -1,10 +1,18 @@
 """
 Core analysis logic for the proChariot package.
 
-This module contains the main functions of the proChariot library.
+This module contains the main functions of the proChariot library
+that perform the LLM-guided analysis of prokaryotic genomes
+based on Bakta annotation files.
 
 Functions included:
-    - analyze: Main function to perform LLM-guided analysis of prokaryotic genomes.
+    Core Analysis Function:
+        - analyze
+    Core Components:
+        - parse_bakta_tsv
+    Helper Functions:        
+        - _dbxrefs_to_dict
+        - _df_to_json
 """
 # -------------[ LIBRARIES ]-------------
 from pathlib import Path

--- a/src/prochariot/core.py
+++ b/src/prochariot/core.py
@@ -38,6 +38,9 @@ def parse_bakta_tsv(tsv_file: Path) -> pd.DataFrame:
     # Skipping the first 5 metadata rows
     df = pd.read_csv(tsv_file, sep="\t", header=5) 
 
+    # Clean up # from the colunm names
+    df.columns = [col.lstrip("# ") for col in df.columns]
+
     return df
 
 # -------------[ CORE FUNCTION ]-------------

--- a/src/prochariot/core.py
+++ b/src/prochariot/core.py
@@ -40,6 +40,26 @@ def _dbxrefs_to_dict(dbxrefs: str) -> dict:
             dbxrefs_dict[key] = value
     return dbxrefs_dict
 
+def _df_to_json(df: pd.DataFrame) -> str:
+    """
+    Converts a Pandas DataFrame to a JSON-formatted string, handling NaN values.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        The DataFrame to convert.
+
+    Returns
+    -------
+    str
+        The JSON-formatted string representation of the DataFrame.
+    """
+    # Replace all pandas 'NaN' with Python's 'None'
+    df = df.replace({pd.NA: None})
+    
+    # Convert the DataFrame to a JSON string
+    return df.to_json(orient="records")
+
 # -------------[ CORE COMPONENTS ]-------------
 def parse_bakta_tsv(tsv_file: Path) -> pd.DataFrame:
     """
@@ -70,26 +90,6 @@ def parse_bakta_tsv(tsv_file: Path) -> pd.DataFrame:
     df['DbXrefs'] = df['DbXrefs'].apply(_dbxrefs_to_dict)
 
     return df
-
-def df_to_json(df: pd.DataFrame) -> str:
-    """
-    Converts a Pandas DataFrame to a JSON-formatted string, handling NaN values.
-
-    Parameters
-    ----------
-    df : pd.DataFrame
-        The DataFrame to convert.
-
-    Returns
-    -------
-    str
-        The JSON-formatted string representation of the DataFrame.
-    """
-    # Replace all pandas 'NaN' with Python's 'None'
-    df = df.replace({pd.NA: None})
-    
-    # Convert the DataFrame to a JSON string
-    return df.to_json(orient="records")
 
 # -------------[ CORE ANALYZE FUNCTION ]-------------
 def analyze(input_directory: str, output_directory: str | None = ".", species: str | None = None, note: str | None = None) -> str:
@@ -132,7 +132,7 @@ if __name__ == "__main__":
 
     # Test pipeline
     df = parse_bakta_tsv(TSV_PATH)
-    json_output = df_to_json(df)
+    json_output = _df_to_json(df)
     
     # Print the first couple of rows of JSON output nicely formatted
     parsed_json = json.loads(json_output)

--- a/src/prochariot/core.py
+++ b/src/prochariot/core.py
@@ -12,8 +12,32 @@ import pandas as pd
 import groq
 
 # -------------[ HELPERS ]-------------
+def _dbxrefs_to_dict(dbxrefs: str) -> dict:
+    """
+    Converts a DbXrefs string from a Bakta .tsv file into a dictionary.
 
-# Section for future _helper() functions
+    Parameters
+    ----------
+    dbxrefs : str
+        The DbXrefs string from a Bakta .tsv file.
+
+    Returns
+    -------
+    dict
+        A dictionary representation of the DbXrefs.
+    """
+    dbxrefs_dict = {}
+
+    # Handle missing values
+    if pd.isna(dbxrefs):
+        return dbxrefs_dict
+
+    entries = dbxrefs.split(", ")
+    for entry in entries:
+        if ":" in entry:
+            key, value = entry.split(":", 1)
+            dbxrefs_dict[key] = value
+    return dbxrefs_dict
 
 # -------------[ CORE COMPONENTS ]-------------
 def parse_bakta_tsv(tsv_file: Path) -> pd.DataFrame:
@@ -40,6 +64,9 @@ def parse_bakta_tsv(tsv_file: Path) -> pd.DataFrame:
 
     # Clean up # from the colunm names
     df.columns = [col.lstrip("# ") for col in df.columns]
+
+    # Parse the 'DbXrefs' column into a nested dictionary
+    df['DbXrefs'] = df['DbXrefs'].apply(_dbxrefs_to_dict)
 
     return df
 

--- a/src/prochariot/core.py
+++ b/src/prochariot/core.py
@@ -7,11 +7,35 @@ Functions included:
     - analyze: Main function to perform LLM-guided analysis of prokaryotic genomes.
 """
 # -------------[ LIBRARIES ]-------------
+from pathlib import Path
 import groq
 
+# -------------[ HELPERS ]-------------
 
-# -------------[ FUNCTIONS ]-------------
-def analyze(input_directory: str, output_directory: str = ".", species: str | None = None, note: str | None = None) -> str:
+# Section for future _helper() functions
+
+# -------------[ CORE COMPONENTS ]-------------
+def parse_bakta_tsv(tsv_file: Path) -> list[dict]
+    """
+    Parses a Bakta .tsv file into a clean list of dictionaries.
+
+    This function is publicly available. It parses the main columns
+    and unnests the 'DbXrefs' column into a nested dictionary.
+
+    Parameters
+    ----------
+    tsv_file : Path
+        The path object pointing to the Bakta .tsv file.
+
+    Returns
+    -------
+    list[dict]
+        A list of dictionaries, where each dict is a processed feature.
+    """
+    pass
+
+# -------------[ CORE FUNCTION ]-------------
+def analyze(input_directory: str, output_directory: str | None = ".", species: str | None = None, note: str | None = None) -> str:
     """
     Performs an LLM-guided analysis of a Bakta output directory.
 
@@ -36,10 +60,9 @@ def analyze(input_directory: str, output_directory: str = ".", species: str | No
     Returns
     -------
     str
-        The path to the final analysis report.
+        The JSON-formatted analysis report.
 
     """
     #TODO: Implement function logic
-    #TODO: output json
     pass
 


### PR DESCRIPTION
### Summary
This PR implements the`.tsv` parsing logic,  which is the first task on the path to the v1.0.0 release.

Parsing logic:
- `parse_bakta_tsv()` reads a Bakta `.tsv` file, skipping the metadata header.
- Cleans the column names.
- Parses the complex `DbXrefs` string into a nested dictionary using `_dbxrefs_to_dict()`.
- Returns a clean, JSON-ready DataFrame
- This DataFrame is transformed into JSON using _df_to_json
- Which replaces `NaN` values with `None`. 

The main `parse_bakta_tsv()`  function is also exposed as part of the public API in `__init__.py` for use in other workflows.

### Related Issue
Closes #15 